### PR TITLE
Warn if the user doesn't set an API KEY.

### DIFF
--- a/ruby/test_unit/basic/BasicTestSetup.rb
+++ b/ruby/test_unit/basic/BasicTestSetup.rb
@@ -2,10 +2,21 @@ require 'appium_lib'
 require 'test/unit'
 
 class BasicTestSetup < Test::Unit::TestCase
+  API_KEY = 'YOUR_API_KEY'
+
+  def api_key
+    if API_KEY == 'YOUR_API_KEY'
+      raise "Please set your API key to run this example (see https://github.com/testobject-sample-scripts/setups/tree/master/ruby/test_unit/watcher)"
+      exit 1
+    else
+      return API_KEY
+    end
+  end
+
   def setup
     desired_capabilities = {
         caps:       {
-            testobject_api_key: 'YOUR_API_KEY',
+            testobject_api_key: api_key,
             testobject_device: 'Motorola_Moto_G_2nd_gen_real'
         },
         appium_lib: {

--- a/ruby/test_unit/watcher/BasicTestSetup.rb
+++ b/ruby/test_unit/watcher/BasicTestSetup.rb
@@ -3,10 +3,21 @@ require 'test/unit'
 require 'test_object_test_result_watcher'
 
 class BasicTestSetup < Test::Unit::TestCase
+  API_KEY = 'YOUR_API_KEY'
+
+  def api_key
+    if API_KEY == 'YOUR_API_KEY'
+      raise "Please set your API key to run this example (see https://github.com/testobject-sample-scripts/setups/tree/master/ruby/test_unit/watcher)"
+      exit 1
+    else
+      return API_KEY
+    end
+  end
+
   def setup
     desired_capabilities = {
         caps:       {
-            testobject_api_key: 'YOUR_API_KEY',
+            testobject_api_key: api_key,
             testobject_device: 'Motorola_Moto_G_2nd_gen_real',
             testobject_report_results: true
         },


### PR DESCRIPTION
If a user doesn't change the API key for the example, `raise` and error
message and call `exit` with a non-zero status.  Like 1.  1 is totally not 0.