### PR TITLE
couple of corrections to resultWatcher for suite setup example

### DIFF
--- a/java/junit/suite/CompleteTestSetup.java
+++ b/java/junit/suite/CompleteTestSetup.java
@@ -9,7 +9,7 @@ public class CompleteTestSetup {
     public TestName testName = new TestName();
 
     @Rule
-    public TestObjectTestResultWatcher resultWatcher = new TestObjectTestResultWatcher();
+    public TestObjectAppiumSuiteWatcher resultWatcher = new TestObjectAppiumSuiteWatcher();
 
     @Before
     public void setUp() throws Exception {
@@ -21,7 +21,7 @@ public class CompleteTestSetup {
 
         driver = new AndroidDriver(new URL("http://appium.testobject.com/wd/hub"), capabilities);
 
-        resultWatcher.setAppiumDriver(driver);
+        resultWatcher.setRemoteWebDriver(driver);
 
     }
 


### PR DESCRIPTION
This example for running a suite setup is not going to work (or even compile) as there are a couple of errors here - this change corrects these.