### PR TITLE
Update teardown behaviour to be more robust.

### DIFF
--- a/ruby/test_unit/basic/BasicTestSetup.rb
+++ b/ruby/test_unit/basic/BasicTestSetup.rb
@@ -5,7 +5,7 @@ class BasicTestSetup < Test::Unit::TestCase
   def setup
     desired_capabilities = {
         caps:       {
-            testobject_api_key: 'YOUR_API_KEY',
+            testobject_api_key: '989A940F0E6341B4BF83A9141C05F225',
             testobject_device: 'Motorola_Moto_G_2nd_gen_real'
         },
         appium_lib: {
@@ -25,6 +25,8 @@ class BasicTestSetup < Test::Unit::TestCase
   end
 
   def teardown
-    @driver.quit
+    @driver.quit if @driver
+  rescue Selenium::WebDriver::Error::UnknownError => e
+    raise e unless e.message.match /Unable to find session with requested ID/
   end
 end

--- a/ruby/test_unit/basic/BasicTestSetup.rb
+++ b/ruby/test_unit/basic/BasicTestSetup.rb
@@ -5,7 +5,7 @@ class BasicTestSetup < Test::Unit::TestCase
   def setup
     desired_capabilities = {
         caps:       {
-            testobject_api_key: '989A940F0E6341B4BF83A9141C05F225',
+            testobject_api_key: 'YOUR_API_KEY',
             testobject_device: 'Motorola_Moto_G_2nd_gen_real'
         },
         appium_lib: {

--- a/ruby/test_unit/watcher/BasicTestSetup.rb
+++ b/ruby/test_unit/watcher/BasicTestSetup.rb
@@ -28,6 +28,8 @@ class BasicTestSetup < Test::Unit::TestCase
   end
 
   def teardown
-    @testwatcher.report_results_and_cleanup(passed?)
+    @driver.quit if @driver
+  rescue Selenium::WebDriver::Error::UnknownError => e
+    raise e unless e.message.match /Unable to find session with requested ID/
   end
 end

--- a/ruby/test_unit/watcher/BasicTestSetup.rb
+++ b/ruby/test_unit/watcher/BasicTestSetup.rb
@@ -28,7 +28,7 @@ class BasicTestSetup < Test::Unit::TestCase
   end
 
   def teardown
-    @driver.quit if @driver
+    @testwatcher.report_results_and_cleanup(passed?) if @testwatcher
   rescue Selenium::WebDriver::Error::UnknownError => e
     raise e unless e.message.match /Unable to find session with requested ID/
   end


### PR DESCRIPTION
Teardown happens regardless of successful setup. If a test fails during setup
(say, because the api key is blank) then `teardown` will still attempt to quit
the driver, raising another exception and making the problem less clear.

Tests also sometimes include a `quit` step, which causes attempts to quit again
to raise a `Selenium::WebDriver::Error::UnknownError` complaining about there being
no test with that ID.  This change catches that error and discards it, but raises any
other.