### PR TITLE
Update Java Junit Suites setup for Multi-DC

### DIFF
--- a/java/junit/suite/CompleteTestSetup.java
+++ b/java/junit/suite/CompleteTestSetup.java
@@ -19,7 +19,7 @@ public class CompleteTestSetup {
         capabilities.setCapability("testobject_api_key", resultWatcher.getApiKey());
         capabilities.setCapability("testobject_test_report_id", resultWatcher.getTestReportId());
 
-        driver = new AndroidDriver(new URL("http://appium.testobject.com/wd/hub"), capabilities);
+        driver = new AndroidDriver(resultWatcher.getTestObjectOrLocalAppiumEndpointURL(), capabilities);
 
         resultWatcher.setRemoteWebDriver(driver);
 

--- a/java/junit/suite/build.gradle
+++ b/java/junit/suite/build.gradle
@@ -1,1 +1,1 @@
-testCompile 'org.testobject:testobject-appium-java-api:0.0.26'
+testCompile 'org.testobject:testobject-appium-java-api:0.1.0'

--- a/java/junit/suite/pom.xml
+++ b/java/junit/suite/pom.xml
@@ -2,6 +2,6 @@
     <dependency>
         <groupId>org.testobject</groupId>
         <artifactId>testobject-appium-java-api</artifactId>
-        <version>0.0.26</version>
+        <version>0.1.0</version>
     </dependency>
 </dependencies>


### PR DESCRIPTION
* Use version `0.1.0` of testobject-appium-java-api, since it is the
  earliest version with multi data center suites support.
* Get the Appium URL from the result watcher, rather than a hardcoded
  URL. Each data center will have a different Appium URL. The result
  watcher sets the correct URL automatically.